### PR TITLE
Icona campo valido

### DIFF
--- a/DxBlazorApp1/Components/Pages/Showcase.razor
+++ b/DxBlazorApp1/Components/Pages/Showcase.razor
@@ -155,7 +155,7 @@
 </DxPopup>
 
 
-<h1>Editor</h1>
+<h1>Form Editor</h1>
 <EditForm Model="@Model" Context="formContext">
     <DataAnnotationsValidator></DataAnnotationsValidator>
     <DxFormLayout CaptionPosition="CaptionPosition.Vertical">
@@ -167,10 +167,10 @@
             <DxTextBox @bind-Text="@Model.Facoltativo" NullText="Facoltativo" ></DxTextBox>
         </DxFormLayoutItem>
 
-         <DxFormLayoutItem Caption="DxTextBox" ColSpanMd="4">
+        <DxFormLayoutItem Caption="DxTextBox" ColSpanMd="4">
             <DxTextBox NullText="Readonly" @bind-Text="@Model.ReadOnlyText" ReadOnly="true"></DxTextBox>
         </DxFormLayoutItem>
-         <DxFormLayoutItem Caption="DxCheckBox" ColSpanMd="4">
+        <DxFormLayoutItem Caption="DxCheckBox" ColSpanMd="4">
             <DxCheckBox @bind-Checked="@Selezionato">Multimedia</DxCheckBox>
         </DxFormLayoutItem>
 
@@ -212,3 +212,6 @@
 
 
 </EditForm>
+
+<h1>Editor</h1>
+<DxTextBox @bind-Text="@Model.TestoObbligatorio"></DxTextBox>

--- a/DxBlazorApp1/wwwroot/css/site.css
+++ b/DxBlazorApp1/wwwroot/css/site.css
@@ -198,3 +198,7 @@ html, body {
 .text-right {text-align: right;}
 .hidden {display: none !important;}
 
+/** https://supportcenter.devexpress.com/ticket/details/t1260418/conditionally-showvalidationicon **/
+.dxbl-image.dxbl-edit-validation-status-icon-valid {
+    display: none !important;
+}


### PR DESCRIPTION
Visualizza l'icona solo se il campo non è valido, altrimenti basta il bordo verde